### PR TITLE
Add alpha percentage info for the TextView color

### DIFF
--- a/draftsman/src/main/kotlin/com/gojek/draftsman/internal/utils/ColorUtils.kt
+++ b/draftsman/src/main/kotlin/com/gojek/draftsman/internal/utils/ColorUtils.kt
@@ -1,5 +1,9 @@
 package com.gojek.draftsman.internal.utils
 
 internal fun getColorHex(color: Int): String {
-    return java.lang.String.format("#%06X", 0xFFFFFF and color)
+    return String.format("#%06X %d%%", 0xFFFFFF and color, getAlphaPercentage(color))
+}
+
+private fun getAlphaPercentage(color: Int): Int {
+    return (color shr 24 and 0xff) * 100 / 255
 }


### PR DESCRIPTION
## Proposed Changes
Add alpha percentage value information for the TextView color to make it clearer for the user whether the text has transparency or not.

![Screenshoot_91823278](https://user-images.githubusercontent.com/44648040/160401094-00f5bb51-c49c-4adb-a4af-01a548ad2f07.png)

## Issue Fixed
Issue #6 
